### PR TITLE
Refactor

### DIFF
--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -1,153 +1,205 @@
+################################################################################
+# Copyright (c) 2017. Vincenzo Lomonaco. All rights reserved.                  #
+# Copyrights licensed under the MIT License.                                   #
+# See the accompanying LICENSE file for terms.                                 #
+#                                                                              #
+# Date: 03-03-2022                                                              #
+# Author: Florian Mies                                                         #
+# Website: https://github.com/travela                                          #
+################################################################################
+
+"""
+
+File to place any kind of generative models 
+and their respective helper functions.
+
+"""
+
+from abc import abstractmethod
 from matplotlib import transforms
 import torch
 import torch.nn as nn
 from collections import OrderedDict
 from torchvision import transforms
 
+from avalanche.models.base_model import BaseModel
+
+
+class Generator(BaseModel):
+    """
+    A base abstract class for generators
+    """
+
+    @abstractmethod
+    def generate(self, batch_size=None):
+        """
+        Lets the generator sample random samples.
+        Output is either a single sample or, if provided,
+        a batch of samples of size "batch_size" 
+        """
+
+
+###########################
+# VARIATIONAL AUTOENCODER #
+###########################
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
+
 class Flatten(nn.Module):
+    '''
+    Simple nn.Module to flatten each tensor of a batch of tensors.
+    '''
+
     def __init__(self):
         super(Flatten, self).__init__()
+
     def forward(self, x):
         batch_size = x.shape[0]
         return x.view(batch_size, -1)
 
+
 class MLP(nn.Module):
-    def __init__(self, hidden_size, last_activation = True):
+    '''
+    Simple nn.Module to create a multi-layer perceptron 
+    with BatchNorm and ReLU activations.
+
+    :param hidden_size: An array indicating the number of neurons in each layer.
+    :type hidden_size: int[]
+    :param last_activation: Indicates whether to add BatchNorm and ReLU 
+                            after the last layer.
+    :type last_activation: Boolean
+    '''
+
+    def __init__(self, hidden_size, last_activation=True):
         super(MLP, self).__init__()
         q = []
         for i in range(len(hidden_size)-1):
             in_dim = hidden_size[i]
             out_dim = hidden_size[i+1]
             q.append(("Linear_%d" % i, nn.Linear(in_dim, out_dim)))
-            if (i < len(hidden_size)-2) or ((i == len(hidden_size) - 2) and (last_activation)):
+            if (i < len(hidden_size)-2) or ((i == len(hidden_size) - 2)
+                                            and (last_activation)):
                 q.append(("BatchNorm_%d" % i, nn.BatchNorm1d(out_dim)))
                 q.append(("ReLU_%d" % i, nn.ReLU(inplace=True)))
         self.mlp = nn.Sequential(OrderedDict(q))
+
     def forward(self, x):
         return self.mlp(x)
-    
+
+
 class Encoder(nn.Module):
-    def __init__(self, shape, nhid = 16, ncond = 0):
+    '''
+    Encoder part of the VAE, computer the latent represenations of the input.
+
+    :param shape: Shape of the input to the network: (channels, height, width)
+    :param nhid: Dimension of last hidden layer
+    '''
+
+    def __init__(self, shape, nhid=128):
         super(Encoder, self).__init__()
         c, h, w = shape
         ww = ((w-8)//2 - 4)//2
         hh = ((h-8)//2 - 4)//2
         self.encode = nn.Sequential(
             Flatten(),
-            nn.Linear(in_features=28*28, out_features=400),
-                      nn.BatchNorm1d(400),
-                      nn.LeakyReLU(),
-                                    MLP([400, 128])
+            nn.Linear(in_features=h*w, out_features=400),
+            nn.BatchNorm1d(400),
+            nn.LeakyReLU(),
+            MLP([400, nhid])
                                    )
 
-    def forward(self, x, y = None):
+    def forward(self, x, y=None):
         x = self.encode(x)
         return x
-        if (y is None):
-            return self.calc_mean(x), self.calc_logvar(x)
-        else:
-            return self.calc_mean(torch.cat((x, y), dim=1)), self.calc_logvar(torch.cat((x, y), dim=1))
+
 
 class Decoder(nn.Module):
-    def __init__(self, shape, nhid = 16, ncond = 0):
+    '''
+    Decoder part of the VAE. Reverses Encoder.
+
+    :param shape: Shape of output: (channels, height, width).
+    :param nhid: Dimension of input.
+    '''
+
+    def __init__(self, shape, nhid=16):
         super(Decoder, self).__init__()
         c, w, h = shape
         self.shape = shape
-        self.decode = nn.Sequential(MLP([nhid+ncond, 64, 128, 256, c*w*h], last_activation = False), nn.Sigmoid())
+        self.decode = nn.Sequential(
+            MLP([nhid, 64, 128, 256, c*w*h], last_activation=False),
+            nn.Sigmoid())
         self.invTrans = transforms.Compose([
                                     transforms.Normalize((0.1307,), (0.3081,))
                         ])
-    def forward(self, z, y = None):
+
+    def forward(self, z, y=None):
         c, w, h = self.shape
         if (y is None):
             return self.invTrans(self.decode(z).view(-1, c, w, h))
         else:
-            return self.invTrans(self.decode(torch.cat((z, y), dim=1)).view(-1, c, w, h))
+            return self.invTrans(self.decode(torch.cat((z, y), dim=1))
+                                 .view(-1, c, w, h))
 
-class Solver(nn.Module):
-  def __init__(self, vae, nhid = 16):
-    super().__init__()
-    self.input_dim = nhid
-    self.vae = vae
-
-  def forward(self, x):
-    self.vae.encoder(x)
 
 class VAE(nn.Module):
-    def __init__(self, shape, nhid = 16, n_classes=10):
+    '''
+    Variational autoencoder module.
+
+    The encoder only computes the latent represenations
+    and we have then two possible output heads: 
+    One for the usual output distribution and one for classification.
+    The latter is an extension the conventional VAE and incorporates
+    a classifier into the network.
+    More details can be found in: https://arxiv.org/abs/1809.10635
+    '''
+
+    def __init__(self, shape, nhid=16, n_classes=10):
         super(VAE, self).__init__()
         self.dim = nhid
         self.encoder = Encoder(shape, nhid)
-        self.calc_mean = MLP([128, nhid], last_activation = False)
-        self.calc_logvar = MLP([128, nhid], last_activation = False)
-        self.classification = MLP([128, n_classes], last_activation = False)
+        self.calc_mean = MLP([128, nhid], last_activation=False)
+        self.calc_logvar = MLP([128, nhid], last_activation=False)
+        self.classification = MLP([128, n_classes], last_activation=False)
         self.decoder = Decoder(shape, nhid)
-        
+
     def sampling(self, mean, logvar):
         eps = torch.randn(mean.shape).to(device)
         sigma = 0.5 * torch.exp(logvar)
         return mean + eps * sigma
-    
+
     # Orginial forward of VAE. We modify this to tie it in with Avalanche plugin syntax
-    #def forward(self, x):
+    # def forward(self, x):
     #    mean, logvar = self.encoder(x)
     #    z = self.sampling(mean, logvar)
     #    return self.decoder(z), mean, logvar
     def forward(self, x):
         return self.encoder(x)
-    
-    def generate(self, batch_size = None):
-        z = torch.randn((batch_size, self.dim)).to(device) if batch_size else torch.randn((1, self.dim)).to(device)
+
+    def generate(self, batch_size=None):
+        z = torch.randn((batch_size, self.dim)).to(
+            device) if batch_size else torch.randn((1, self.dim)).to(device)
         res = self.decoder(z)
         if not batch_size:
             res = res.squeeze(0)
         return res
 
-class cVAE(nn.Module):
-    def __init__(self, shape, nclass, nhid = 16, ncond = 16):
-        super(cVAE, self).__init__()
-        self.dim = nhid
-        self.encoder = Encoder(shape, nhid, ncond = ncond)
-        self.calc_mean = MLP([128+ncond, nhid], last_activation = False)
-        self.calc_logvar = MLP([128+ncond, nhid], last_activation = False)
-        self.decoder = Decoder(shape, nhid, ncond = ncond)
-        self.label_embedding = nn.Embedding(nclass, ncond)
-        
-    def sampling(self, mean, logvar):
-        eps = torch.randn(mean.shape).to(device)
-        sigma = 0.5 * torch.exp(logvar)
-        return mean + eps * sigma
-    
-    def forward(self, x, y):
-        y = self.label_embedding(y)
-        mean, logvar = self.encoder(x, y)
-        z = self.sampling(mean, logvar)
-        return self.decoder(z, y), mean, logvar
-    
-    def generate(self, class_idx):
-        if (type(class_idx) is int):
-            class_idx = torch.tensor(class_idx)
-        class_idx = class_idx.to(device)
-        if (len(class_idx.shape) == 0):
-            batch_size = None
-            class_idx = class_idx.unsqueeze(0)
-            z = torch.randn((1, self.dim)).to(device)
-        else:
-            batch_size = class_idx.shape[0]
-            z = torch.randn((batch_size, self.dim)).to(device) 
-        y = self.label_embedding(class_idx)
-        res = self.decoder(z, y)
-        if not batch_size:
-            res = res.squeeze(0)
-        return res
 
 # Loss functions    
-BCE_loss = nn.BCELoss(reduction = "sum")
-MSE_loss = nn.MSELoss(reduction = "sum")
+BCE_loss = nn.BCELoss(reduction="sum")
+MSE_loss = nn.MSELoss(reduction="sum")
 CE_loss = nn.CrossEntropyLoss()
+
+
 def VAE_loss(X, X_hat, mean, logvar):
+    '''
+    Loss function of a VAE using mean squared error for reconstruction loss.
+    This is the criterion for VAE training loop.
+
+    :param X: Original input batch.
+    :param X_hat: Reconstructed input after subsequent Encoder and Decoder.
+    :param mean: mean of the VAE output distribution.
+    :param logvar: logvar of the VAE output distribution.
+    '''
     reconstruction_loss = MSE_loss(X_hat, X)
     KL_divergence = 0.5 * torch.sum(-1 - logvar + torch.exp(logvar) + mean**2)
     return reconstruction_loss + KL_divergence

--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -105,7 +105,7 @@ class Encoder(nn.Module):
             nn.Linear(in_features=h*w, out_features=400),
             nn.BatchNorm1d(400),
             nn.LeakyReLU(),
-            MLP([400, nhid])
+            MLP([400, latent_dim])
                                    )
 
     def forward(self, x, y=None):

--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -92,10 +92,10 @@ class Encoder(nn.Module):
     Encoder part of the VAE, computer the latent represenations of the input.
 
     :param shape: Shape of the input to the network: (channels, height, width)
-    :param nhid: Dimension of last hidden layer
+    :param latent_dim: Dimension of last hidden layer
     '''
 
-    def __init__(self, shape, nhid=128):
+    def __init__(self, shape, latent_dim=128):
         super(Encoder, self).__init__()
         c, h, w = shape
         ww = ((w-8)//2 - 4)//2
@@ -156,7 +156,7 @@ class VAE(nn.Module):
     def __init__(self, shape, nhid=16, n_classes=10):
         super(VAE, self).__init__()
         self.dim = nhid
-        self.encoder = Encoder(shape, nhid)
+        self.encoder = Encoder(shape, latent_dim=128)
         self.calc_mean = MLP([128, nhid], last_activation=False)
         self.calc_logvar = MLP([128, nhid], last_activation=False)
         self.classification = MLP([128, n_classes], last_activation=False)

--- a/avalanche/training/plugins/generative_replay.py
+++ b/avalanche/training/plugins/generative_replay.py
@@ -3,7 +3,8 @@ from avalanche.benchmarks.utils import AvalancheDataset
 from avalanche.core import SupervisedPlugin
 from avalanche.training.templates.supervised import SupervisedTemplate
 import torch
-                                      
+
+
 class GenerativeReplayPlugin(SupervisedPlugin):
     """
     Experience replay plugin.
@@ -57,25 +58,28 @@ class GenerativeReplayPlugin(SupervisedPlugin):
         Dataloader to build batches containing examples from both memories and
         the training dataset
         """
-        self.classes_until_now.append(strategy.experience.classes_in_this_experience)
-        
-        print("Classes so far: ", self.classes_until_now, len(self.classes_until_now))
+        self.classes_until_now.append(
+            strategy.experience.classes_in_this_experience)
+
+        print("Classes so far: ", self.classes_until_now,
+              len(self.classes_until_now))
         if self.untrained_solver:
-          # The solver needs to train on the first experience before it can label generated data
-          # as well as the generator needs to train first.
-          self.untrained_solver = False
-          return
-        #self.classes_until_now = [class_id for exp_classes in self.classes_until_now for class_id in exp_classes]
+            # The solver needs to train on the first experience before it can label generated data
+            # as well as the generator needs to train first.
+            self.untrained_solver = False
+            return
+        # self.classes_until_now = [class_id for exp_classes in self.classes_until_now for class_id in exp_classes]
         # Sample data from generator
-        memory = self.generator.generate(len(strategy.adapted_dataset)*(len(self.classes_until_now)-1)).to(strategy.device)
+        memory = self.generator.generate(
+            len(strategy.adapted_dataset)*(len(self.classes_until_now)-1)).to(strategy.device)
         # Label the generated data using the current solver model
         strategy.model.eval()
         with torch.no_grad():
             memory_output = strategy.model(memory).argmax(dim=-1)
         strategy.model.train()
         # Create an AvalancheDataset from memory data and labels
-        memory = AvalancheDataset(torch.utils.data.TensorDataset(memory.detach().cpu(), memory_output.detach().cpu()))
-
+        memory = AvalancheDataset(torch.utils.data.TensorDataset(
+            memory.detach().cpu(), memory_output.detach().cpu()))
 
         batch_size = self.batch_size
         if batch_size is None:
@@ -84,7 +88,7 @@ class GenerativeReplayPlugin(SupervisedPlugin):
         batch_size_mem = self.batch_size_mem
         if batch_size_mem is None:
             batch_size_mem = strategy.train_mb_size
-        #Update strategies dataloader by mixing current experience's data with generated data.
+        # Update strategies dataloader by mixing current experience's data with generated data.
         strategy.dataloader = ReplayDataLoader(
             strategy.adapted_dataset,
             memory,
@@ -94,29 +98,33 @@ class GenerativeReplayPlugin(SupervisedPlugin):
             num_workers=num_workers,
             shuffle=shuffle)
 
+
 class VAEPlugin(SupervisedPlugin):
 
     def after_forward(
         self, strategy, *args, **kwargs
     ):
         # Forward call computes the representations in the latent space. They are stored at strategy.mb_output and can be used here
-          strategy.mean, strategy.logvar = strategy.model.calc_mean(strategy.mb_output), strategy.model.calc_logvar(strategy.mb_output)
-          z = strategy.model.sampling(strategy.mean, strategy.logvar)
-          strategy.mb_x_recon = strategy.model.decoder(z)
-          
+        strategy.mean, strategy.logvar = strategy.model.calc_mean(
+            strategy.mb_output), strategy.model.calc_logvar(strategy.mb_output)
+        z = strategy.model.sampling(strategy.mean, strategy.logvar)
+        strategy.mb_x_recon = strategy.model.decoder(z)
+
     def after_eval_forward(
         self, strategy, *args, **kwargs
     ):
         # Forward call computes the representations in the latent space. They are stored at strategy.mb_output and can be used here
-          strategy.mean, strategy.logvar = strategy.model.calc_mean(strategy.mb_output), strategy.model.calc_logvar(strategy.mb_output)
-          z = strategy.model.sampling(strategy.mean, strategy.logvar)
-          strategy.mb_x_recon = strategy.model.decoder(z)
+        strategy.mean, strategy.logvar = strategy.model.calc_mean(
+            strategy.mb_output), strategy.model.calc_logvar(strategy.mb_output)
+        z = strategy.model.sampling(strategy.mean, strategy.logvar)
+        strategy.mb_x_recon = strategy.model.decoder(z)
+
 
 class trainGeneratorPlugin(SupervisedPlugin):
     def after_training_exp(self, strategy: "SupervisedTemplate", **kwargs):
-      print("Start training of Generator ... ")
-      #strategy.generator.train(strategy.dataloader)
-      strategy.plugins[1].generator_strategy.train(strategy.experience) 
-      # Originally wanted to train directly on strategy.dataloader which already contains generated data
-      # However training requires an experience which has an attribute dataset with teh entire dataset.
-      # We there do the sampling step again
+        print("Start training of Generator ... ")
+        # strategy.generator.train(strategy.dataloader)
+        strategy.plugins[1].generator_strategy.train(strategy.experience) 
+        # Originally wanted to train directly on strategy.dataloader which already contains generated data
+        # However training requires an experience which has an attribute dataset with teh entire dataset.
+        # We there do the sampling step again

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -349,7 +349,7 @@ class GenerativeReplay(SupervisedTemplate):
                 optimizer=optimizer_generator,
                 criterion=VAE_loss, train_mb_size=64, 
                 train_epochs=10,
-                eval_mb_size=32, device=device)
+                eval_mb_size=32, device=device, generative_replay=True)
 
         rp = GenerativeReplayPlugin(generator=self.generator_strategy)
 
@@ -430,7 +430,8 @@ class VAETraining(SupervisedTemplate):
         else:
             plugins.append(vaep)
 
-        if base_kwargs['generative_replay']:
+        if ('generative_replay' in base_kwargs) and base_kwargs['generative_replay']:
+            print("Train VAE with generative replay.")
             self.model = model
             plugins.append(GenerativeReplayPlugin(generator=self))
 

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -287,8 +287,8 @@ class GenerativeReplay(SupervisedTemplate):
     and Generator as described in https://arxiv.org/abs/1705.08690.
 
     For the case where the Generator is the model itself that is to be trained,
-    please simply add the GenerativeReplayPlugin(generator=self) to 
-    your Generator's strategy, similar like in the VAETraining class.
+    please simply add the GenerativeReplayPlugin() when instantiating 
+    your Generator's strategy.
 
     See GenerativeReplayPlugin for more details.
     This strategy does not use task identities.
@@ -350,8 +350,7 @@ class GenerativeReplay(SupervisedTemplate):
                 criterion=VAE_loss, train_mb_size=64, 
                 train_epochs=10,
                 eval_mb_size=32, device=device,
-                plugins=[GenerativeReplayPlugin()],
-                generative_replay=False)
+                plugins=[GenerativeReplayPlugin()])
 
         rp = GenerativeReplayPlugin(generator=self.generator_strategy)
 
@@ -403,7 +402,6 @@ class VAETraining(SupervisedTemplate):
         plugins: Optional[List[SupervisedPlugin]] = None,  # Optional
         evaluator: EvaluationPlugin = default_evaluator,
         eval_every=-1,
-        generative_replay=False,
         **base_kwargs
     ):
         """
@@ -432,11 +430,6 @@ class VAETraining(SupervisedTemplate):
             plugins = [vaep]
         else:
             plugins.append(vaep)
-
-        # if generative_replay:
-        #    print("Train VAE with generative replay.")
-        #    self.model = model
-        #    plugins.append(GenerativeReplayPlugin(generator=self))
 
         super().__init__(
             model,

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -401,6 +401,7 @@ class VAETraining(SupervisedTemplate):
         plugins: Optional[List[SupervisedPlugin]] = None,  # Optional
         evaluator: EvaluationPlugin = default_evaluator,
         eval_every=-1,
+        generative_replay=False,
         **base_kwargs
     ):
         """
@@ -430,7 +431,7 @@ class VAETraining(SupervisedTemplate):
         else:
             plugins.append(vaep)
 
-        if ('generative_replay' in base_kwargs) and base_kwargs['generative_replay']:
+        if generative_replay:
             print("Train VAE with generative replay.")
             self.model = model
             plugins.append(GenerativeReplayPlugin(generator=self))

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -349,7 +349,9 @@ class GenerativeReplay(SupervisedTemplate):
                 optimizer=optimizer_generator,
                 criterion=VAE_loss, train_mb_size=64, 
                 train_epochs=10,
-                eval_mb_size=32, device=device, generative_replay=True)
+                eval_mb_size=32, device=device,
+                plugins=[GenerativeReplayPlugin()],
+                generative_replay=False)
 
         rp = GenerativeReplayPlugin(generator=self.generator_strategy)
 
@@ -431,10 +433,10 @@ class VAETraining(SupervisedTemplate):
         else:
             plugins.append(vaep)
 
-        if generative_replay:
-            print("Train VAE with generative replay.")
-            self.model = model
-            plugins.append(GenerativeReplayPlugin(generator=self))
+        # if generative_replay:
+        #    print("Train VAE with generative replay.")
+        #    self.model = model
+        #    plugins.append(GenerativeReplayPlugin(generator=self))
 
         super().__init__(
             model,

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -337,12 +337,13 @@ class GenerativeReplay(SupervisedTemplate):
             self.generator_strategy = base_kwargs['generator']
         else:
             # By default we use a fully-connected VAE.
+            generator = VAE((1, 28, 28), nhid=2)
             lr = 0.01
             from torch.optim import Adam  # this should go to the model file
             optimizer_generator = Adam(filter(
-                lambda p: p.requires_grad, self.generator.parameters()), lr=lr,
+                lambda p: p.requires_grad, generator.parameters()), lr=lr,
                  weight_decay=0.0001)
-            generator = VAE((1, 28, 28), nhid=2)
+
             self.generator_strategy = VAETraining(
                 model=generator, 
                 optimizer=optimizer_generator,

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -328,8 +328,13 @@ class GenerativeReplay(SupervisedTemplate):
             :class:`~avalanche.training.BaseTemplate` constructor arguments.
         """
 
-        # By default we use a fully-connected VAE. The user should be able to input their own generator.
-        self.generator = VAE((1, 28, 28), nhid=2)
+        # Check if user inputs a generator model
+        if 'generator' in base_kwargs:
+            self.generator = base_kwargs['generator']
+        else:
+            # By default we use a fully-connected VAE.
+            self.generator = VAE((1, 28, 28), nhid=2)
+
         lr = 0.01
         from torch.optim import Adam  # this should go to the model file
         optimizer_generator = Adam(filter(
@@ -340,6 +345,7 @@ class GenerativeReplay(SupervisedTemplate):
         rp = GenerativeReplayPlugin(generator=gg)
 
         tgp = trainGeneratorPlugin()
+
         if plugins is None:
             plugins = [tgp, rp]
         else:


### PR DESCRIPTION
Separation of concerns: made the plugin more modular: We have a separate VAETraining now (which is used by default in the GenerativeReplay strategy). Simply adding the GenerativeReplayPlugin to this VAETraining class will make it train continually. Therefore it can be switched with other generators.

Some more refactoring.

Update Docstrings

