### PR TITLE
Pass device to VAE model

### DIFF
--- a/avalanche/models/__init__.py
+++ b/avalanche/models/__init__.py
@@ -19,4 +19,4 @@ from .ncm_classifier import NCMClassifier
 from .base_model import BaseModel
 from .helper_method import as_multitask
 from .pnn import PNN
-from .generator import VAE, VAE_loss
+from .generator import *

--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -42,7 +42,7 @@ class Generator(BaseModel):
 ###########################
 # VARIATIONAL AUTOENCODER #
 ###########################
-device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+# device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
 
 class Flatten(nn.Module):
@@ -178,8 +178,8 @@ class VAE(Generator, nn.Module):
         Output is either a single sample if batch_size=None,
         else it is a batch of samples of size "batch_size". 
         """
-        z = torch.randn((batch_size, self.dim)).to(
-            device) if batch_size else torch.randn((1, self.dim)).to(device)
+        z = torch.randn((batch_size, self.dim)
+                        ) if batch_size else torch.randn((1, self.dim))
         res = self.decoder(z)
         if not batch_size:
             res = res.squeeze(0)
@@ -189,7 +189,7 @@ class VAE(Generator, nn.Module):
         """
         VAE 'reparametrization trick'
         """
-        eps = torch.randn(mean.shape).to(device)
+        eps = torch.randn(mean.shape)
         sigma = 0.5 * torch.exp(logvar)
         return mean + eps * sigma
 
@@ -224,3 +224,6 @@ def VAE_loss(X, forward_output):
     reconstruction_loss = MSE_loss(X_hat, X)
     KL_divergence = 0.5 * torch.sum(-1 - logvar + torch.exp(logvar) + mean**2)
     return reconstruction_loss + KL_divergence
+
+
+__all__ = ["VAE, VAE_loss"]

--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -226,4 +226,4 @@ def VAE_loss(X, forward_output):
     return reconstruction_loss + KL_divergence
 
 
-__all__ = ["VAE, VAE_loss"]
+__all__ = ["VAE", "VAE_loss"]

--- a/avalanche/models/generator.py
+++ b/avalanche/models/generator.py
@@ -151,7 +151,7 @@ class VAE(Generator, nn.Module):
     More details can be found in: https://arxiv.org/abs/1809.10635
     '''
 
-    def __init__(self, shape, nhid=16, n_classes=10):
+    def __init__(self, shape, nhid=16, n_classes=10, device="cpu"):
         """
         :param shape: Shape of each input sample
         :param nhid: Dimension of latent space of Encoder.
@@ -160,6 +160,7 @@ class VAE(Generator, nn.Module):
         """
         super(VAE, self).__init__()
         self.dim = nhid
+        self.device = device
         self.encoder = Encoder(shape, latent_dim=128)
         self.calc_mean = MLP([128, nhid], last_activation=False)
         self.calc_logvar = MLP([128, nhid], last_activation=False)
@@ -178,8 +179,9 @@ class VAE(Generator, nn.Module):
         Output is either a single sample if batch_size=None,
         else it is a batch of samples of size "batch_size". 
         """
-        z = torch.randn((batch_size, self.dim)
-                        ) if batch_size else torch.randn((1, self.dim))
+        z = torch.randn((batch_size, self.dim)).to(
+            self.device) if batch_size else torch.randn((1, self.dim)).to(
+                self.device)
         res = self.decoder(z)
         if not batch_size:
             res = res.squeeze(0)
@@ -189,7 +191,7 @@ class VAE(Generator, nn.Module):
         """
         VAE 'reparametrization trick'
         """
-        eps = torch.randn(mean.shape)
+        eps = torch.randn(mean.shape).to(self.device)
         sigma = 0.5 * torch.exp(logvar)
         return mean + eps * sigma
 

--- a/avalanche/training/plugins/generative_replay.py
+++ b/avalanche/training/plugins/generative_replay.py
@@ -33,6 +33,12 @@ class GenerativeReplayPlugin(SupervisedPlugin):
     and one part of generative data for each class 
     that has been encountered so far.
 
+    In this version of the plugin the number of replay samples is 
+    increased with each new experience. Another way to implempent 
+    the algorithm is by weighting the loss function and give more 
+    importance to the replayed data as the number of experiences 
+    increases. This will be implemented as an option for the user soon.
+
     :param batch_size: the size of the data batch. If set to `None`, it
         will be set equal to the strategy's batch size.
     :param batch_size_mem: the size of the memory batch. If

--- a/avalanche/training/supervised/strategy_wrappers.py
+++ b/avalanche/training/supervised/strategy_wrappers.py
@@ -349,7 +349,7 @@ class GenerativeReplay(SupervisedTemplate):
         else:
             # By default we use a fully-connected VAE as the generator.
             # model:
-            generator = VAE((1, 28, 28), nhid=2)
+            generator = VAE((1, 28, 28), nhid=2, device=device)
             # optimzer:
             lr = 0.01
             from torch.optim import Adam


### PR DESCRIPTION
We removed the additional computation of the device in the VAE model file.

Improve docstrings.

Adjust exports of models.generator.